### PR TITLE
Add pick rate, ban rate, KDA and elo bracket filter

### DIFF
--- a/apps/dataset/src/index.ts
+++ b/apps/dataset/src/index.ts
@@ -23,6 +23,7 @@ import {
     type RiotSummonerSpell,
 } from "./riot";
 import type { SummonerSpellData } from "@draftgap/core/src/models/dataset/SummonerSpellData";
+import { EloBracket } from "@draftgap/core/src/models/rank/elo-bracket";
 
 const BATCH_SIZE = 10;
 
@@ -100,25 +101,33 @@ async function main() {
         },
     }));
 
-    const datasetCurrentPatch = await getDataset(
-        currentVersion,
-        champions,
-        runes,
-        items,
-        summonerSpells,
-    );
-    const dataset30days = await getDataset(
-        "30",
-        champions,
-        runes,
-        items,
-        summonerSpells,
-    );
+    for (const eloBracket of EloBracket) {
+        console.log("Building dataset for elo bracket", eloBracket);
 
-    deleteDatasetMatchupSynergyData(datasetCurrentPatch);
+        const datasetCurrentPatch = await getDataset(
+            currentVersion,
+            champions,
+            runes,
+            items,
+            summonerSpells,
+            eloBracket,
+        );
+        const dataset30days = await getDataset(
+            "30",
+            champions,
+            runes,
+            items,
+            summonerSpells,
+            eloBracket,
+        );
 
-    await storeDataset(datasetCurrentPatch, { name: "current-patch" });
-    await storeDataset(dataset30days, { name: "30-days" });
+        deleteDatasetMatchupSynergyData(datasetCurrentPatch);
+
+        await storeDataset(datasetCurrentPatch, {
+            name: `${eloBracket}/current-patch`,
+        });
+        await storeDataset(dataset30days, { name: `${eloBracket}/30-days` });
+    }
 }
 
 function riotRunesToRuneData(runes: RiotRunePath[]) {
@@ -209,6 +218,7 @@ async function getDataset(
     runes: RiotRunePath[],
     items: Record<string, RiotItem>,
     summonerSpells: Record<string, RiotSummonerSpell>,
+    eloBracket: EloBracket,
 ) {
     console.log("Getting dataset for version", version);
     const dataset: Dataset = {
@@ -233,7 +243,11 @@ async function getDataset(
                 async (champion) =>
                     [
                         champion,
-                        await getChampionDataFromLolalytics(version, champion),
+                        await getChampionDataFromLolalytics(
+                            version,
+                            champion,
+                            eloBracket,
+                        ),
                     ] as const,
             ),
         );

--- a/apps/dataset/src/lolalytics/index.ts
+++ b/apps/dataset/src/lolalytics/index.ts
@@ -7,17 +7,29 @@ import {
     defaultChampionRoleData,
 } from "@draftgap/core/src/models/dataset/ChampionRoleData";
 import { LOLALYTICS_ROLES, type LolalyticsRole } from "./roles";
-import { getLolalyticsQwikChampion } from "./qwik";
+import { getKdaFromStats, getLolalyticsQwikChampion } from "./qwik";
 import { getLolalyticsQwikChampion2 } from "./qwik-champion2";
 import type { RiotChampion } from "../riot";
+import {
+    DEFAULT_ELO_BRACKET,
+    type EloBracket,
+} from "@draftgap/core/src/models/rank/elo-bracket";
 
 export async function getChampionDataFromLolalytics(
     version: string,
     champion: RiotChampion,
+    tier: EloBracket = DEFAULT_ELO_BRACKET,
 ) {
     const [championData, champion2Data] = await Promise.all([
-        getLolalyticsQwikChampion(version, champion.id),
-        getLolalyticsQwikChampion2(version, champion.id),
+        getLolalyticsQwikChampion(
+            version,
+            champion.id,
+            undefined,
+            undefined,
+            undefined,
+            tier,
+        ),
+        getLolalyticsQwikChampion2(version, champion.id, undefined, tier),
     ]);
 
     // If data is not available, throw
@@ -33,8 +45,15 @@ export async function getChampionDataFromLolalytics(
 
     const rolePromises = remainingRoles.map((role) =>
         Promise.all([
-            getLolalyticsQwikChampion(version, champion.id, role),
-            getLolalyticsQwikChampion2(version, champion.id, role),
+            getLolalyticsQwikChampion(
+                version,
+                champion.id,
+                role,
+                undefined,
+                undefined,
+                tier,
+            ),
+            getLolalyticsQwikChampion2(version, champion.id, role, tier),
         ]),
     );
     const roleDataResults = await Promise.allSettled(rolePromises);
@@ -68,6 +87,9 @@ export async function getChampionDataFromLolalytics(
                     wins: Math.round(
                         (championData.header.n * championData.header.wr) / 100,
                     ),
+                    pickRate: championData.header.pr,
+                    banRate: championData.header.br,
+                    kda: getKdaFromStats(championData.sidebar.stats),
                     matchup: Object.fromEntries(
                         LOLALYTICS_ROLES.map((role) => {
                             const data = championData.enemy[role];

--- a/apps/dataset/src/lolalytics/qwik-champion2.ts
+++ b/apps/dataset/src/lolalytics/qwik-champion2.ts
@@ -1,5 +1,9 @@
 import { retry } from "../utils";
 import { type LolalyticsRole } from "./roles";
+import {
+    DEFAULT_ELO_BRACKET,
+    type EloBracket,
+} from "@draftgap/core/src/models/rank/elo-bracket";
 
 export type LolalyticsChampion2Response = {
     team_h: string[];
@@ -26,6 +30,7 @@ export async function getLolalyticsQwikChampion2(
     role?: LolalyticsRole,
     // matchupId?: string,
     // matchupRole?: LolalyticsRole
+    tier: EloBracket = DEFAULT_ELO_BRACKET,
 ) {
     championId = championId.toLowerCase();
     if (championId === "monkeyking") {
@@ -38,7 +43,7 @@ export async function getLolalyticsQwikChampion2(
     const queryParams = new URLSearchParams();
     queryParams.append("ep", "build-team");
     queryParams.append("v", "1");
-    queryParams.append("tier", "emerald_plus");
+    queryParams.append("tier", tier);
     queryParams.append("queue", "ranked");
     queryParams.append("region", "all");
     queryParams.append("patch", patch);

--- a/apps/dataset/src/lolalytics/qwik.ts
+++ b/apps/dataset/src/lolalytics/qwik.ts
@@ -1,5 +1,9 @@
 import { retry } from "../utils";
 import { type LolalyticsRole } from "./roles";
+import {
+    DEFAULT_ELO_BRACKET,
+    type EloBracket,
+} from "@draftgap/core/src/models/rank/elo-bracket";
 
 export type QwikLolalyticsData = {
     header: Header;
@@ -137,6 +141,21 @@ export type Stats = {
     stats: Array<Array<number | string>>;
     count: number;
 };
+
+// `stats.stats` is a list of [name, flag, average, percentile, rank] tuples
+// (order is not guaranteed), e.g. ["kills", 0, 6.21, 50, 54].
+export function getKdaFromStats(stats: Stats) {
+    function getAverage(name: string) {
+        const stat = stats.stats.find((s) => s[0] === name);
+        return typeof stat?.[2] === "number" ? stat[2] : 0;
+    }
+
+    return {
+        kills: getAverage("kills"),
+        deaths: getAverage("deaths"),
+        assists: getAverage("assists"),
+    };
+}
 
 export type Time = {
     time: { [key: string]: number };
@@ -287,6 +306,7 @@ export async function getLolalyticsQwikChampion(
     role?: LolalyticsRole,
     matchupId?: string,
     matchupRole?: LolalyticsRole,
+    tier: EloBracket = DEFAULT_ELO_BRACKET,
 ) {
     championId = championId.toLowerCase();
     if (championId === "monkeyking") {
@@ -303,7 +323,7 @@ export async function getLolalyticsQwikChampion(
     patch = patch.split(".").slice(0, 2).join(".");
 
     const queryParams = new URLSearchParams();
-    queryParams.append("tier", "emerald_plus");
+    queryParams.append("tier", tier);
     queryParams.append("region", "all");
     queryParams.append("patch", patch);
     if (role) {

--- a/apps/frontend/src/components/common/KdaText.tsx
+++ b/apps/frontend/src/components/common/KdaText.tsx
@@ -1,0 +1,29 @@
+import { Component } from "solid-js";
+
+type Props = {
+    kills: number;
+    deaths: number;
+    assists: number;
+};
+
+export const KdaText: Component<Props> = (props) => {
+    const ratio = () =>
+        props.deaths === 0
+            ? props.kills + props.assists
+            : (props.kills + props.assists) / props.deaths;
+
+    return (
+        <span
+            class="relative"
+            style={{
+                "font-variant-numeric": "tabular-nums",
+            }}
+        >
+            {props.kills.toFixed(1)} / {props.deaths.toFixed(1)} /{" "}
+            {props.assists.toFixed(1)}
+            <span class="text-neutral-400 ml-1">
+                ({ratio().toFixed(2)})
+            </span>
+        </span>
+    );
+};

--- a/apps/frontend/src/components/common/PercentageText.tsx
+++ b/apps/frontend/src/components/common/PercentageText.tsx
@@ -1,0 +1,42 @@
+import { Component, Show } from "solid-js";
+import { formatPercentage } from "../../utils/rating";
+import { Icon } from "solid-heroicons";
+import { exclamationTriangle } from "solid-heroicons/solid-mini";
+import { tooltip } from "../../directives/tooltip";
+// eslint-disable-next-line
+tooltip;
+
+type Props = {
+    percentage: number;
+    games?: number;
+};
+
+export const PercentageText: Component<Props> = (props) => {
+    return (
+        <span
+            class="relative"
+            style={{
+                "font-variant-numeric": "tabular-nums",
+            }}
+        >
+            {formatPercentage(props.percentage / 100)}%
+            <Show when={props.games !== undefined && props.games < 1000}>
+                <div
+                    class="absolute -top-1 -right-6"
+                    // @ts-ignore
+                    use:tooltip={{
+                        content:
+                            "This might not be accurate due to the small sample size of " +
+                            Math.ceil(props.games!) +
+                            " games",
+                    }}
+                >
+                    <Icon
+                        path={exclamationTriangle}
+                        class="text-yellow-500 w-5 h-5"
+                    />
+                </div>
+            </Show>
+        </span>
+    );
+};

--- a/apps/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/apps/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -7,6 +7,10 @@ import {
     RiskLevel,
     displayNameByRiskLevel,
 } from "@draftgap/core/src/risk/risk-level";
+import {
+    EloBracket,
+    displayNameByEloBracket,
+} from "@draftgap/core/src/models/rank/elo-bracket";
 import { useUser } from "../../contexts/UserContext";
 import { useMedia } from "../../hooks/useMedia";
 import {
@@ -30,6 +34,13 @@ export default function SettingsDialog() {
         (level) => ({
             value: level,
             label: displayNameByRiskLevel[level],
+        }),
+    );
+
+    const eloBracketOptions: ButtonGroupOption<EloBracket>[] = EloBracket.map(
+        (bracket) => ({
+            value: bracket,
+            label: displayNameByEloBracket[bracket],
         }),
     );
 
@@ -106,6 +117,33 @@ export default function SettingsDialog() {
                         })
                     }
                 />
+                <div class="flex flex-col gap-1 mt-2">
+                    <span class="text-lg uppercase block">Elo</span>
+                    <ButtonGroup
+                        options={eloBracketOptions}
+                        selected={config.eloBracket}
+                        size="sm"
+                        onChange={(value: EloBracket) =>
+                            setConfig({
+                                eloBracket: value,
+                            })
+                        }
+                    />
+                </div>
+                <div class="flex space-x-16 items-center justify-between mt-2">
+                    <span class="text-lg uppercase">
+                        Adjust ratings using pick/ban rate
+                    </span>
+                    <Switch
+                        checked={config.usePickBanRateAdjustments}
+                        onChange={() =>
+                            setConfig({
+                                usePickBanRateAdjustments:
+                                    !config.usePickBanRateAdjustments,
+                            })
+                        }
+                    />
+                </div>
             </div>
             <div>
                 <h3 class="text-3xl uppercase">UI</h3>

--- a/apps/frontend/src/components/draft/DraftTable.tsx
+++ b/apps/frontend/src/components/draft/DraftTable.tsx
@@ -18,6 +18,8 @@ import { Icon } from "solid-heroicons";
 import { star } from "solid-heroicons/solid";
 import { star as starOutline } from "solid-heroicons/outline";
 import { RatingText } from "../common/RatingText";
+import { PercentageText } from "../common/PercentageText";
+import { KdaText } from "../common/KdaText";
 import { createMustSelectToast } from "../../utils/toast";
 import { useUser } from "../../contexts/UserContext";
 import { useDraftSuggestions } from "../../contexts/DraftSuggestionsContext";
@@ -269,6 +271,59 @@ export default function DraftTable() {
                 ].name.localeCompare(
                     dataset()!.championData[b.getValue<string>(id)].name,
                 ),
+        },
+        {
+            header: "Pick Rate",
+            accessorFn: (suggestion) =>
+                dataset()!.championData[suggestion.championKey]?.statsByRole[
+                    suggestion.role
+                ]?.pickRate ?? 0,
+            cell: (info) => (
+                <div class="flex justify-end">
+                    <PercentageText percentage={info.getValue<number>()} />
+                </div>
+            ),
+        },
+        {
+            header: "Ban Rate",
+            accessorFn: (suggestion) =>
+                dataset()!.championData[suggestion.championKey]?.statsByRole[
+                    suggestion.role
+                ]?.banRate ?? 0,
+            cell: (info) => (
+                <div class="flex justify-end">
+                    <PercentageText percentage={info.getValue<number>()} />
+                </div>
+            ),
+        },
+        {
+            header: "KDA",
+            accessorFn: (suggestion) => {
+                const roleData = dataset()!.championData[
+                    suggestion.championKey
+                ]?.statsByRole[suggestion.role];
+                if (!roleData) return 0;
+                return (
+                    (roleData.kda.kills + roleData.kda.assists) /
+                    (roleData.kda.deaths || 1)
+                );
+            },
+            cell: (info) => {
+                const roleData = () =>
+                    dataset()!.championData[info.row.original.championKey]
+                        ?.statsByRole[info.row.original.role];
+                return (
+                    <Show when={roleData()}>
+                        <div class="flex justify-end">
+                            <KdaText
+                                kills={roleData()!.kda.kills}
+                                deaths={roleData()!.kda.deaths}
+                                assists={roleData()!.kda.assists}
+                            />
+                        </div>
+                    </Show>
+                );
+            },
         },
         ...(config.showAdvancedWinrates
             ? ([

--- a/apps/frontend/src/contexts/DatasetContext.tsx
+++ b/apps/frontend/src/contexts/DatasetContext.tsx
@@ -9,11 +9,15 @@ import {
     DATASET_VERSION,
     Dataset,
 } from "@draftgap/core/src/models/dataset/Dataset";
+import { EloBracket } from "@draftgap/core/src/models/rank/elo-bracket";
+import { useUser } from "./UserContext";
 
-const fetchDataset = async (name: "30-days" | "current-patch") => {
+type DatasetKey = { tier: EloBracket; name: "30-days" | "current-patch" };
+
+const fetchDataset = async ({ tier, name }: DatasetKey) => {
     try {
         const response = await fetch(
-            `https://bucket.draftgap.com/datasets/v${DATASET_VERSION}/${name}.json`,
+            `https://bucket.draftgap.com/datasets/v${DATASET_VERSION}/${tier}/${name}.json`,
         );
         const json = await response.json();
         return json as Dataset;
@@ -24,9 +28,17 @@ const fetchDataset = async (name: "30-days" | "current-patch") => {
 };
 
 function createDatasetContext() {
-    const [dataset] = createResource("current-patch", fetchDataset);
+    const { config } = useUser();
 
-    const [dataset30Days] = createResource("30-days", fetchDataset);
+    const [dataset] = createResource(
+        () => ({ tier: config.eloBracket, name: "current-patch" as const }),
+        fetchDataset,
+    );
+
+    const [dataset30Days] = createResource(
+        () => ({ tier: config.eloBracket, name: "30-days" as const }),
+        fetchDataset,
+    );
 
     const isLoaded = () =>
         dataset() !== undefined && dataset30Days() !== undefined;

--- a/apps/frontend/src/contexts/DraftAnalysisContext.tsx
+++ b/apps/frontend/src/contexts/DraftAnalysisContext.tsx
@@ -63,6 +63,10 @@ export function createDraftAnalysisContext() {
         ignoreChampionWinrates: config.ignoreChampionWinrates,
         riskLevel: config.riskLevel,
         minGames: config.minGames,
+        usePickBanRateAdjustments: config.usePickBanRateAdjustments,
+        banRateRatingBonus: config.banRateRatingBonus,
+        pickRatePriorScale: config.pickRatePriorScale,
+        referencePickRate: config.referencePickRate,
     });
 
     const allyDraftAnalysis = createMemo(() => {

--- a/apps/frontend/src/contexts/UserContext.tsx
+++ b/apps/frontend/src/contexts/UserContext.tsx
@@ -8,6 +8,7 @@ import {
 import { createStore } from "solid-js/store";
 import { Role } from "@draftgap/core/src/models/Role";
 import { DraftGapConfig } from "@draftgap/core/src/models/user/Config";
+import { DEFAULT_ELO_BRACKET } from "@draftgap/core/src/models/rank/elo-bracket";
 
 type FavouritePick = `${string}:${Role}`;
 
@@ -16,6 +17,11 @@ const DEFAULT_CONFIG: DraftGapConfig = {
     ignoreChampionWinrates: false,
     riskLevel: "medium",
     minGames: 1000,
+    eloBracket: DEFAULT_ELO_BRACKET,
+    usePickBanRateAdjustments: false,
+    banRateRatingBonus: 20,
+    pickRatePriorScale: 1,
+    referencePickRate: 0.05,
 
     // UI
     showFavouritesAtTop: false,

--- a/packages/core/src/draft/analysis.ts
+++ b/packages/core/src/draft/analysis.ts
@@ -21,6 +21,10 @@ export interface AnalyzeDraftConfig {
     ignoreChampionWinrates: boolean;
     riskLevel: RiskLevel;
     minGames: number;
+    usePickBanRateAdjustments: boolean;
+    banRateRatingBonus: number;
+    pickRatePriorScale: number;
+    referencePickRate: number;
 }
 
 export function analyzeDraft(
@@ -33,10 +37,10 @@ export function analyzeDraft(
     const priorGames = priorGamesByRiskLevel[config.riskLevel];
 
     const allyChampionRating = !config.ignoreChampionWinrates
-        ? analyzeChampions(dataset, fullDataset, team, priorGames)
+        ? analyzeChampions(dataset, fullDataset, team, priorGames, config)
         : { totalRating: 0, winrate: 0, championResults: [] };
     const enemyChampionRating = !config.ignoreChampionWinrates
-        ? analyzeChampions(dataset, fullDataset, enemy, priorGames)
+        ? analyzeChampions(dataset, fullDataset, enemy, priorGames, config)
         : { totalRating: 0, winrate: 0, championResults: [] };
 
     const allyDuoRating = analyzeDuos(fullDataset, team, priorGames);
@@ -81,6 +85,7 @@ export function analyzeChampions(
     synergyMatchupDataset: Dataset,
     team: Map<Role, string>,
     priorGames: number,
+    config: AnalyzeDraftConfig,
 ): AnalyzeChampionsResult {
     const championResults: AnalyzeChampionResult[] = [];
     let totalRating = 0;
@@ -92,6 +97,7 @@ export function analyzeChampions(
             role,
             championKey,
             priorGames,
+            config,
         );
 
         championResults.push(championResult);
@@ -110,6 +116,7 @@ export function analyzeChampion(
     role: Role,
     championKey: string,
     priorGames: number,
+    config: AnalyzeDraftConfig,
 ) {
     // Get stats for this patch
     const championData = dataset.championData[championKey];
@@ -132,6 +139,14 @@ export function analyzeChampion(
             ? 0.5
             : fullChampionRoleData.wins / fullChampionRoleData.games;
 
+    // A rarely-played champion/role has a less representative sample than its
+    // game count alone suggests, so widen the prior pull as pick rate drops.
+    const pickRateConfidence = config.usePickBanRateAdjustments
+        ? Math.min(1, roleData.pickRate / 100 / config.referencePickRate)
+        : 1;
+    const effectivePriorGames =
+        priorGames * (1 + config.pickRatePriorScale * (1 - pickRateConfidence));
+
     const stats = addStats(
         {
             wins: roleData.wins,
@@ -140,13 +155,19 @@ export function analyzeChampion(
         // Scale prior stats by winrate of expected rating, as we expect the champion to have a similar winrate to the expected rating
         // We estimate the expected rating to be the rank winrate
         {
-            wins: priorGames * fullChampionRoleWinrate,
-            games: priorGames,
+            wins: effectivePriorGames * fullChampionRoleWinrate,
+            games: effectivePriorGames,
         },
         // TOOD: if 30 days has no games, add other prior games
     );
 
-    const rating = winrateToRating(stats.wins / stats.games);
+    let rating = winrateToRating(stats.wins / stats.games);
+
+    // Champions that get banned often never get to prove their winrate in the
+    // data (survivorship bias), so nudge their rating up proportionally.
+    if (config.usePickBanRateAdjustments) {
+        rating += config.banRateRatingBonus * (roleData.banRate / 100);
+    }
 
     return {
         role,

--- a/packages/core/src/models/dataset/ChampionRoleData.ts
+++ b/packages/core/src/models/dataset/ChampionRoleData.ts
@@ -6,6 +6,13 @@ import { Role } from "../Role";
 export interface ChampionRoleData {
     games: number;
     wins: number;
+    pickRate: number;
+    banRate: number;
+    kda: {
+        kills: number;
+        deaths: number;
+        assists: number;
+    };
     matchup: Record<Role, Record<string, ChampionMatchupData>>;
     synergy: Record<Role, Record<string, ChampionSynergyData>>;
     damageProfile: ChampionDamageProfile;
@@ -19,6 +26,13 @@ export function defaultChampionRoleData(): ChampionRoleData {
     return {
         games: 0,
         wins: 0,
+        pickRate: 0,
+        banRate: 0,
+        kda: {
+            kills: 0,
+            deaths: 0,
+            assists: 0,
+        },
         matchup: [0, 1, 2, 3, 4].reduce(
             (acc, role) => ({ ...acc, [role]: {} }),
             {},

--- a/packages/core/src/models/dataset/Dataset.ts
+++ b/packages/core/src/models/dataset/Dataset.ts
@@ -5,7 +5,7 @@ import { ItemData } from "./ItemData";
 import { ratingToWinrate, winrateToRating } from "../../rating/ratings";
 import { SummonerSpellData } from "./SummonerSpellData";
 
-export const DATASET_VERSION = "5";
+export const DATASET_VERSION = "6";
 
 export interface Dataset {
     version: string;

--- a/packages/core/src/models/rank/elo-bracket.ts
+++ b/packages/core/src/models/rank/elo-bracket.ts
@@ -1,0 +1,10 @@
+export const EloBracket = ["platinum", "emerald_plus", "diamond_plus"] as const;
+export type EloBracket = (typeof EloBracket)[number];
+
+export const displayNameByEloBracket: Record<EloBracket, string> = {
+    platinum: "Platinum",
+    emerald_plus: "Emerald+",
+    diamond_plus: "Diamond+",
+};
+
+export const DEFAULT_ELO_BRACKET: EloBracket = "emerald_plus";

--- a/packages/core/src/models/user/Config.ts
+++ b/packages/core/src/models/user/Config.ts
@@ -1,4 +1,5 @@
 import { RiskLevel } from "../../risk/risk-level";
+import { EloBracket } from "../rank/elo-bracket";
 
 export type StatsSite = "op.gg" | "u.gg" | "lolalytics";
 
@@ -15,6 +16,11 @@ export type DraftGapConfig = {
     ignoreChampionWinrates: boolean;
     riskLevel: RiskLevel;
     minGames: number;
+    eloBracket: EloBracket;
+    usePickBanRateAdjustments: boolean;
+    banRateRatingBonus: number;
+    pickRatePriorScale: number;
+    referencePickRate: number;
 
     // DRAFT SUGGESTIONS
     showFavouritesAtTop: boolean;


### PR DESCRIPTION
Surfaces pick rate, ban rate and KDA per champion/role (previously discarded from lolalytics data) and lets users filter by elo bracket (Platinum / Emerald+ / Diamond+). Pick rate and ban rate can optionally feed into the suggestion algorithm as a Bayesian-prior confidence adjustment and a ban-rate survivorship-bias rating bonus, gated behind a new opt-in setting (usePickBanRateAdjustments, default off).

Bumps DATASET_VERSION to 6 (new storage path adds a {tier}/ segment), so the dataset app must repopulate S3 before the frontend is deployed against it.